### PR TITLE
Implement exponential map for translator

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -36,7 +36,7 @@ jobs:
           - name: epga3d
             descriptor: "epga3d:1,1,1,1;Scalar:1;MultiVector:1,e23,-e13,e12|e0,-e023,e013,-e012|e123,e1,e2,e3|e0123,e01,e02,e03;Rotor:1,e23,-e13,e12;Point:e123,-e023,e013,-e012;Plane:e0,e1,e2,e3;Line:e01,e02,e03|e23,-e13,e12;Translator:1,e01,e02,e03;Motor:1,e23,-e13,e12|e0123,e01,e02,e03;PointAndPlane:e123,-e023,e013,-e012|e0,e1,e2,e3"
           - name: ppga3d
-            descriptor: "ppga3d:0,1,1,1;Scalar:1;MultiVector:1,e23,-e13,e12|e0,-e023,e013,-e012|e123,e1,e2,e3|e0123,e01,e02,e03;Rotor:1,e23,-e13,e12;Point:e123,-e023,e013,-e012;Plane:e0,e1,e2,e3;Line:e01,e02,e03|e23,-e13,e12;Translator:1,e01,e02,e03;Motor:1,e23,-e13,e12|e0123,e01,e02,e03;PointAndPlane:e123,-e023,e013,-e012|e0,e1,e2,e3"
+            descriptor: "ppga3d:0,1,1,1;Scalar:1;MultiVector:1,e23,-e13,e12|e0,-e023,e013,-e012|e123,e1,e2,e3|e0123,e01,e02,e03;Rotor:1,e23,-e13,e12;Point:e123,-e023,e013,-e012;Plane:e0,e1,e2,e3;Line:e01,e02,e03|e23,-e13,e12;Branch:e01,e02,e03;Translator:1,e01,e02,e03;Motor:1,e23,-e13,e12|e0123,e01,e02,e03;PointAndPlane:e123,-e023,e013,-e012|e0,e1,e2,e3"
           - name: hpga3d
             descriptor: "hpga3d:-1,1,1,1;Scalar:1;MultiVector:1,e23,-e13,e12|e0,-e023,e013,-e012|e123,e1,e2,e3|e0123,e01,e02,e03;Rotor:1,e23,-e13,e12;Point:e123,-e023,e013,-e012;Plane:e0,e1,e2,e3;Line:e01,e02,e03|e23,-e13,e12;Translator:1,e01,e02,e03;Motor:1,e23,-e13,e12|e0123,e01,e02,e03;PointAndPlane:e123,-e023,e013,-e012|e0,e1,e2,e3"
     steps:

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -30,7 +30,7 @@ jobs:
           - name: epga2d
             descriptor: "epga2d:1,1,1;Scalar:1;MultiVector:1,e12,e1,e2|e0,e012,e01,-e02;Rotor:1,e12;Point:e12,e01,-e02;Plane:e0,e2,e1;Translator:1,e01,-e02;Motor:1,e12,e01,-e02;MotorDual:e012,e0,e2,e1"
           - name: ppga2d
-            descriptor: "ppga2d:0,1,1;Scalar:1;MultiVector:1,e12,e1,e2|e0,e012,e01,-e02;Rotor:1,e12;Point:e12,e01,-e02;Plane:e0,e2,e1;Translator:1,e01,-e02;Motor:1,e12,e01,-e02;MotorDual:e012,e0,e2,e1"
+            descriptor: "ppga2d:0,1,1;Scalar:1;MultiVector:1,e12,e1,e2|e0,e012,e01,-e02;Rotor:1,e12;Point:e12,e01,-e02;IdealPoint:e01,-e02;Plane:e0,e2,e1;Translator:1,e01,-e02;Motor:1,e12,e01,-e02;MotorDual:e012,e0,e2,e1"
           - name: hpga2d
             descriptor: "hpga2d:-1,1,1;Scalar:1;MultiVector:1,e12,e1,e2|e0,e012,e01,-e02;Rotor:1,e12;Point:e12,e01,-e02;Plane:e0,e2,e1;Translator:1,e01,-e02;Motor:1,e12,e01,-e02;MotorDual:e012,e0,e2,e1"
           - name: epga3d

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -36,7 +36,7 @@ jobs:
           - name: epga3d
             descriptor: "epga3d:1,1,1,1;Scalar:1;MultiVector:1,e23,-e13,e12|e0,-e023,e013,-e012|e123,e1,e2,e3|e0123,e01,e02,e03;Rotor:1,e23,-e13,e12;Point:e123,-e023,e013,-e012;Plane:e0,e1,e2,e3;Line:e01,e02,e03|e23,-e13,e12;Translator:1,e01,e02,e03;Motor:1,e23,-e13,e12|e0123,e01,e02,e03;PointAndPlane:e123,-e023,e013,-e012|e0,e1,e2,e3"
           - name: ppga3d
-            descriptor: "ppga3d:0,1,1,1;Scalar:1;MultiVector:1,e23,-e13,e12|e0,-e023,e013,-e012|e123,e1,e2,e3|e0123,e01,e02,e03;Rotor:1,e23,-e13,e12;Point:e123,-e023,e013,-e012;Plane:e0,e1,e2,e3;Line:e01,e02,e03|e23,-e13,e12;Branch:e01,e02,e03;Translator:1,e01,e02,e03;Motor:1,e23,-e13,e12|e0123,e01,e02,e03;PointAndPlane:e123,-e023,e013,-e012|e0,e1,e2,e3"
+            descriptor: "ppga3d:0,1,1,1;Scalar:1;MultiVector:1,e23,-e13,e12|e0,-e023,e013,-e012|e123,e1,e2,e3|e0123,e01,e02,e03;Rotor:1,e23,-e13,e12;Point:e123,-e023,e013,-e012;Plane:e0,e1,e2,e3;Line:e01,e02,e03|e23,-e13,e12;IdealLine:e01,e02,e03;Translator:1,e01,e02,e03;Motor:1,e23,-e13,e12|e0123,e01,e02,e03;PointAndPlane:e123,-e023,e013,-e012|e0,e1,e2,e3"
           - name: hpga3d
             descriptor: "hpga3d:-1,1,1,1;Scalar:1;MultiVector:1,e23,-e13,e12|e0,-e023,e013,-e012|e123,e1,e2,e3|e0123,e01,e02,e03;Rotor:1,e23,-e13,e12;Point:e123,-e023,e013,-e012;Plane:e0,e1,e2,e3;Line:e01,e02,e03|e23,-e13,e12;Translator:1,e01,e02,e03;Motor:1,e23,-e13,e12|e0123,e01,e02,e03;PointAndPlane:e123,-e023,e013,-e012|e0,e1,e2,e3"
     steps:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,7 @@ impl Powf for ppga3d::Motor {
     }
 }
 
-impl Exp for ppga3d::Branch {
+impl Exp for ppga3d::IdealLine {
     type Output = ppga3d::Translator;
 
     fn exp(self) -> ppga3d::Translator {
@@ -219,10 +219,10 @@ impl Exp for ppga3d::Branch {
 }
 
 impl Ln for ppga3d::Translator {
-    type Output = ppga3d::Branch;
+    type Output = ppga3d::IdealLine;
 
-    fn ln(self) -> ppga3d::Branch {
-        ppga3d::Branch {
+    fn ln(self) -> ppga3d::IdealLine {
+        ppga3d::IdealLine {
             g0: simd::Simd32x3 {
                 f32x3: [self.g0[1] / self.g0[0], self.g0[2] / self.g0[0], self.g0[3] / self.g0[0]],
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,6 +206,38 @@ impl Powf for ppga3d::Motor {
     }
 }
 
+impl Exp for ppga3d::Branch {
+    type Output = ppga3d::Translator;
+
+    fn exp(self) -> ppga3d::Translator {
+        ppga3d::Translator {
+            g0: simd::Simd32x4 {
+                f32x4: [1.0, self.g0[0], self.g0[1], self.g0[2]],
+            }
+        }
+    }
+}
+
+impl Ln for ppga3d::Translator {
+    type Output = ppga3d::Branch;
+
+    fn ln(self) -> ppga3d::Branch {
+        ppga3d::Branch {
+            g0: simd::Simd32x3 {
+                f32x3: [self.g0[1] / self.g0[0], self.g0[2] / self.g0[0], self.g0[3] / self.g0[0]],
+            }
+        }
+    }
+}
+
+impl Powf for ppga3d::Translator {
+    type Output = Self;
+
+    fn powf(self, exponent: f32) -> Self {
+        (ppga3d::Scalar { g0: exponent } * self.ln()).exp()
+    }
+}
+
 /// All elements set to `0.0`
 pub trait Zero {
     fn zero() -> Self;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,37 @@ impl Powf for epga1d::ComplexNumber {
     }
 }
 
+impl Exp for ppga2d::IdealPoint {
+    type Output = ppga2d::Translator;
+
+    fn exp(self) -> ppga2d::Translator {
+        ppga2d::Translator {
+            g0: simd::Simd32x3 {
+                f32x3: [1.0, self.g0[0], self.g0[1]],
+            }
+        }
+    }
+}
+
+impl Ln for ppga2d::Translator {
+    type Output = ppga2d::IdealPoint;
+
+    fn ln(self) -> ppga2d::IdealPoint {
+        ppga2d::IdealPoint {
+            g0: simd::Simd32x2 {
+                f32x2: [self.g0[1] / self.g0[0], self.g0[2] / self.g0[0]],
+            }
+        }
+    }
+}
+
+impl Powf for ppga2d::Translator {
+    type Output = Self;
+
+    fn powf(self, exponent: f32) -> Self {
+        (ppga2d::Scalar { g0: exponent } * self.ln()).exp()
+    }
+}
 impl Exp for ppga2d::Point {
     type Output = ppga2d::Motor;
 


### PR DESCRIPTION
The logarithm of a translator is a line with only degenerate components (`e01`, `e02`, `e03`). I called it an *Ideal Line* (name is taken from [klein](https://github.com/jeremyong/klein)) as it is a line at infinity (a translation is a rotation around a line at infinity). The exponential of an Ideal Line is a translator again. Implementing `Ln` and `Exp` for `Translator` and `IdealLine` allows to write code generic over *motor-like* types.

```rust
#[test]
fn foo() {
    let b = ppga3d:: IdealLine { g0: simd::Simd32x3 {
        f32x3: [1.0, 2.0, 3.0]
    } };

    // A translator by 1 e1 units, 2 e2 units and 3 e3 units.
    let t = b.exp();

    // A translator by 0.5 e1 units, 1 e2 units and 1.5 e3 units.
    let t_half = t.powf(0.5);

    let b_half = t_half.ln();

    unsafe { assert_eq!(
        b_half.g0.f32x3,
        [0.5, 1.0, 1.5]
    ) };
}
```